### PR TITLE
Added support for regular Apex 7 Keyboard

### DIFF
--- a/51-apex.rules
+++ b/51-apex.rules
@@ -1,3 +1,6 @@
 SUBSYSTEM=="input", GROUP="input", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1618", MODE="0666", GROUP="plugdev"
 KERNEL=="hidraw*", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1618", MODE="0666", GROUP="plugdev"
+
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1612", MODE="0666", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1612", MODE="0666", GROUP="plugdev"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Steelseries Apex 7 TKL on Linux
+# Steelseries Apex 7 on Linux
 
 This is raw and unpolished code. Use it at your own risk.
 
@@ -7,7 +7,7 @@ This is raw and unpolished code. Use it at your own risk.
 - Activate or switch a configuration
 - Update the OLED image or write text to the display
 
-## installation
+## Installation
 
 ```pip install -r requirements.txt```
 
@@ -19,16 +19,39 @@ This requires a `udev` ruleset.
 
 ## CLI usage
 
+### Load profile
+
+Takes in the the profile number.
+
 - `./cli.py config 1`
+
+### Oled screen control
+
 - `./cli.py oledblank`
 - `./cli.py oled ./images/grimm.png`
 - `./cli.py oledtext "Hello" "from the other side"`
-- ` ./cli.py color SYMBOLS_LEFT green F1,F2,F3,F4 red -- black` set colors, takes in pairs of (keycode or region, color). The special region "--" sets the following color on all keys that have not been used so far. Definitions in `keys.py`.
+
+### Color
+
+Takes in pairs of (keycode(s) or region(s), color). You can define multiple keycodes or regions in a given pair by using a comma separator.
+
+Examples:
+
 - `./cli.py color ALL orange`
 - `./cli.py color ALPHA c26838`
 - `./cli.py color F9,F10,F11,F12 red`
+- `./cli.py color SYMBOLS_LEFT green F1,F2,F3,F4 red -- black`
 
+Available regions:
 
-## Other devices
+- `FKEYS`: Function keys
+- `ALPHA`: Letters and space bar
+- `NUMERIC`: Number row
+- `SYMBOLS_LEFT`: Symbols left of alpha keys
+- `SYMBOLS_RIGHT1`: Symbols right of alpha keys
+- `SYMBOLS_RIGHT2` M1 to M6 and arrow keys
+- `KEYPAD`: Numeric key pad (not available for Apex7 TKL)
+- `ALL`: All keys
+- `--`: Special region that sets the following color on all keys that have not been used so far.
 
-Unclear, presumably the regular Apex 7 would also work (would need adjustment of the product ID and key map in `keys.py`).
+See `keys.py` for list key codes

--- a/keys.py
+++ b/keys.py
@@ -3,6 +3,7 @@ KEYMAP = {}
 KEYS_ALPHA = [kc + 0x04 for kc in range(25+1)] # A-Z in order
 for idx, character in enumerate([chr(ord('A') + kc) for kc in range(25+1)]):
     KEYMAP[ character ] = KEYS_ALPHA[ idx ]
+
 KEYS_NUMERIC = [kc + 0x1e for kc in range(10+1)] # 1,2,3,4,5,6,7,8,9,0 in order
 for idx, character in enumerate([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]):
     KEYMAP[ str(character) ] = KEYS_NUMERIC[ idx ]
@@ -12,64 +13,85 @@ for fkey, kc in [("F%s" % (i+1), 0x3A + i) for i in range(12)]:
     KEYMAP[ fkey ] = kc
     KEYS_FKEYS.append(kc)
 
-KEYS_SPECIAL = {}
+KEYS_KEYPAD = {
+    "NUMLOCK": 0x53,     # Num Lock/Clear
+    "KP_SLASH": 0x54,    # /
+    "KP_ASTERISK": 0x55, # *
+    "KP_MINUS": 0x56,    # -
+    "KP_PLUS": 0x57,     # +
+    "KP_ENTER": 0x58,    # Enter
+    "KP_1": 0x59,        # 1, End
+    "KP_2": 0x5a,        # 2, Down Arrow
+    "KP_3": 0x5b,        # 3, PageDn
+    "KP_4": 0x5c,        # 4, Left Arrow
+    "KP_5": 0x5d,        # 5
+    "KP_6": 0x5e,        # 6, Right Arrow
+    "KP_7": 0x5f,        # 7, Home
+    "KP_8": 0x60,        # 8, Up Arrow
+    "KP_9": 0x61,        # 9, Page Up
+    "KP_0": 0x62,        # 0, Insert
+    "KP_DOT": 0x63,      # ., Delete
+}
+KEYMAP.update(KEYS_KEYPAD)
 
-KEYS_SPECIAL[ "`" ] = 0x35
-KEYS_SPECIAL[ "~" ] = 0x35
-KEYS_SPECIAL[ "ESC" ] = 0x29
-KEYS_SPECIAL[ "BACKSPACE" ] = 0x2A
-KEYS_SPECIAL[ "TAB" ] = 0x2B
-KEYS_SPECIAL[ "-" ] = 0x2D
-KEYS_SPECIAL[ "_" ] = 0x2D
-KEYS_SPECIAL[ "+" ] = 0x2E
-KEYS_SPECIAL[ "=" ] = 0x2E
-KEYS_SPECIAL[ "[" ] = 0x2F
-KEYS_SPECIAL[ "{" ] = 0x2F
-KEYS_SPECIAL[ "]" ] = 0x30
-KEYS_SPECIAL[ "}" ] = 0x30
-KEYS_SPECIAL[ ":" ] = 0x33
-KEYS_SPECIAL[ ";" ] = 0x33
-KEYS_SPECIAL[ "'" ] = 0x34
-KEYS_SPECIAL[ "\"" ] = 0x34
-KEYS_SPECIAL[ "<" ] = 0x36
-KEYS_SPECIAL[ "," ] = 0x36
-KEYS_SPECIAL[ ">" ] = 0x37
-KEYS_SPECIAL[ "." ] = 0x37
-KEYS_SPECIAL[ "/" ] = 0x38
-KEYS_SPECIAL[ "?" ] = 0x38
-KEYS_SPECIAL[ "CAPSLOCK" ] = 0x39
-KEYS_SPECIAL[ "M1" ] = 0x49
-KEYS_SPECIAL[ "INS" ] = 0x49
-KEYS_SPECIAL[ "M2" ] = 0x4A
-KEYS_SPECIAL[ "HOME" ] = 0x4A
-KEYS_SPECIAL[ "M3" ] = 0x4B
-KEYS_SPECIAL[ "PG_UP" ] = 0x4B
-KEYS_SPECIAL[ "M4" ] = 0x4C
-KEYS_SPECIAL[ "DEL" ] = 0x4C
-KEYS_SPECIAL[ "M5" ] = 0x4D
-KEYS_SPECIAL[ "END" ] = 0x4D
-KEYS_SPECIAL[ "M6" ] = 0x4E
-KEYS_SPECIAL[ "PG_DN" ] = 0x4E
-KEYS_SPECIAL[ "ARROW_RIGHT" ] = 0x4F
-KEYS_SPECIAL[ "ARROW_LEFT" ] = 0x50
-KEYS_SPECIAL[ "ARROW_DOWN" ] = 0x51
-KEYS_SPECIAL[ "ARROW_UP" ] = 0x52
-KEYS_SPECIAL[ "CTRL_LEFT" ] = 0xE0
-KEYS_SPECIAL[ "SHIFT_LEFT" ] = 0xE1
-KEYS_SPECIAL[ "ALT_LEFT" ] = 0xE2
-KEYS_SPECIAL[ "WIN_LEFT" ] = 0xE3
-KEYS_SPECIAL[ "CTRL_RIGHT" ] = 0xE4
-KEYS_SPECIAL[ "SHIFT_RIGHT" ] = 0xE5
-KEYS_SPECIAL[ "ALT_RIGHT" ] = 0xE6
-KEYS_SPECIAL[ "WIN_RIGHT" ] = 0xE7
-KEYS_SPECIAL[ "STEEL_META" ] = 0xF0
-KEYS_SPECIAL[ " " ] = 0x2C
-KEYS_SPECIAL[ "SPACE" ] = 0x2C
-KEYS_SPECIAL[ "RETURN" ] = 0x28
-KEYS_SPECIAL[ "\\" ] = 0x31
-KEYS_SPECIAL[ "|" ] = 0x31
-KEYS_SPECIAL[ "<" ] = 0x64
-KEYS_SPECIAL[ ">" ] = 0x64
+KEYS_SPECIAL = {
+    "`": 0x35,
+    "~": 0x35,
+    "ESC": 0x29,
+    "BACKSPACE": 0x2A,
+    "TAB": 0x2B,
+    "-": 0x2D,
+    "_": 0x2D,
+    "+": 0x2E,
+    "=": 0x2E,
+    "[": 0x2F,
+    "{": 0x2F,
+    "]": 0x30,
+    "}": 0x30,
+    ":": 0x33,
+    ";": 0x33,
+    "'": 0x34,
+    "\"": 0x34,
+    "<": 0x36,
+    ",": 0x36,
+    ">": 0x37,
+    ".": 0x37,
+    "/": 0x38,
+    "?": 0x38,
+    "CAPSLOCK": 0x39,
+    "M1": 0x49,
+    "INS": 0x49,
+    "M2": 0x4A,
+    "HOME": 0x4A,
+    "M3": 0x4B,
+    "PG_UP": 0x4B,
+    "M4": 0x4C,
+    "DEL": 0x4C,
+    "M5": 0x4D,
+    "END": 0x4D,
+    "M6": 0x4E,
+    "PG_DN": 0x4E,
+    "ARROW_RIGHT": 0x4F,
+    "ARROW_LEFT": 0x50,
+    "ARROW_DOWN": 0x51,
+    "ARROW_UP": 0x52,
+    "CTRL_LEFT": 0xE0,
+    "SHIFT_LEFT": 0xE1,
+    "ALT_LEFT": 0xE2,
+    "WIN_LEFT": 0xE3,
+    "CTRL_RIGHT": 0xE4,
+    "SHIFT_RIGHT": 0xE5,
+    "ALT_RIGHT": 0xE6,
+    "WIN_RIGHT": 0xE7,
+    "STEEL_META": 0xF0,
+    " ": 0x2C,
+    "SPACE": 0x2C,
+    "RETURN": 0x28,
+    "\\": 0x31,
+    "|": 0x31,
+    "<": 0x64,
+    ">": 0x64,
+}
 
 for character, addr in KEYS_SPECIAL.items():
     KEYMAP[ character ] = addr
@@ -81,14 +103,16 @@ def get_key_codes(charmap):
             res.add(KEYS_SPECIAL[char])
     return res
 
-KEY_REGIONS = {}
-KEY_REGIONS['FKEYS'] = KEYS_FKEYS
-KEY_REGIONS['ALPHA'] = KEYS_ALPHA + list(get_key_codes(["SPACE"]))
-KEY_REGIONS['NUMERIC'] = KEYS_NUMERIC
-KEY_REGIONS['SYMBOLS_LEFT'] = get_key_codes(["ESC", "`", "TAB", "CAPSLOCK", "SHIFT_LEFT", "CTRL_LEFT", "WIN_LEFT", "ALT_LEFT"])
-KEY_REGIONS['SYMBOLS_RIGHT1'] = get_key_codes(["BACKSPACE", "RETURN", "-", "=", "[", "]", ";", "'", "\\", ",", ".", "/", "SHIFT_RIGHT", "CTRL_RIGHT", "WIN_RIGHT", "STEEL_META", "ALT_RIGHT"])
-KEY_REGIONS['SYMBOLS_RIGHT2'] = get_key_codes(["M1", "M2", "M3", "M4", "M5", "M6", "ARROW_UP", "ARROW_DOWN", "ARROW_LEFT", "ARROW_RIGHT"])
-KEY_REGIONS["ALL"] = set(KEYMAP.values())
+KEY_REGIONS = {
+    "FKEYS": KEYS_FKEYS,
+    "ALPHA": KEYS_ALPHA + list(get_key_codes(["SPACE"])),
+    "NUMERIC": KEYS_NUMERIC,
+    "SYMBOLS_LEFT": get_key_codes(["ESC", "`", "TAB", "CAPSLOCK", "SHIFT_LEFT", "CTRL_LEFT", "WIN_LEFT", "ALT_LEFT"]),
+    "SYMBOLS_RIGHT1": get_key_codes(["BACKSPACE", "RETURN", "-", "=", "[", "]", ";", "'", "\\", ",", ".", "/", "SHIFT_RIGHT", "CTRL_RIGHT", "WIN_RIGHT", "STEEL_META", "ALT_RIGHT"]),
+    "SYMBOLS_RIGHT2": get_key_codes(["M1", "M2", "M3", "M4", "M5", "M6", "ARROW_UP", "ARROW_DOWN", "ARROW_LEFT", "ARROW_RIGHT"]),
+    "KEYPAD": KEYS_KEYPAD.values(),
+    "ALL": set(KEYMAP.values()),
+}
 
 def others(used_keycodes):
     return set(KEYMAP.values()) - set(used_keycodes)


### PR DESCRIPTION
Hi @FrankGrimm, I've recently acquired a regular Steelseries Apex 7 keyboard, and I was very pleased to find this repository!

Please find support for the regular version:
- The `Device` class will match on the first Apex 7 keyboard found (regular or tkl). I think this is the more convenient approach, so the user doesn't have to bother configuring the model name somewhere.
- Added the keypad keycodes, and the `KEYPAD` region
- Updated udev rule
- Updated doc
